### PR TITLE
rake db:createでデータベースを作成できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,15 @@ $ brew install mysql
 $ mysql.sever start
 ```
 
-# コードチェッカ
+## データベースの作成手順
+
+  1. データベース作成
+
+    ```shell
+    $ bundle exec rake db:create
+    ```
+
+## コードチェッカ
 
 プルリクを出す前に下記のコマンドを実行し、コーディング規約に反していない事を確認して下さい。
 

--- a/recordOfReading/Gemfile
+++ b/recordOfReading/Gemfile
@@ -1,8 +1,11 @@
 source 'https://rubygems.org'
 
-
+# core
 gem 'rails', '4.2.6'
-gem 'sqlite3'
+
+# db
+gem 'mysql2'
+
 gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.1.0'

--- a/recordOfReading/Gemfile.lock
+++ b/recordOfReading/Gemfile.lock
@@ -94,6 +94,7 @@ GEM
     mini_portile2 (2.1.0)
     minitest (5.9.1)
     multi_json (1.12.1)
+    mysql2 (0.4.4)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
     parser (2.3.1.2)
@@ -159,7 +160,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.12)
     sysexits (1.2.0)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -189,12 +189,12 @@ DEPENDENCIES
   haml_lint
   jbuilder (~> 2.0)
   jquery-rails
+  mysql2
   rails (= 4.2.6)
   rubocop
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   spring
-  sqlite3
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/recordOfReading/config/database.yml
+++ b/recordOfReading/config/database.yml
@@ -5,21 +5,25 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: mysql2
   pool: 5
   timeout: 5000
-
 development:
   <<: *default
-  database: db/development.sqlite3
-
+  username: root
+  password: password
+  database: recode_of_reading_development
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
-
+  username: root
+  password: password
+  database: recode_of_reading_test
 production:
   <<: *default
-  database: db/production.sqlite3
+  host: <%= ENV['OMOTENASHI_DB_HOST'] %>
+  database: <%= ENV['OMOTENASHI_DB_NAME'] %>
+  username: <%= ENV['OMOTENASHI_DB_USERNAME'] %>
+  password: <%= ENV['OMOTENASHI_DB_PASSWORD'] %>


### PR DESCRIPTION
rake db:createでデータベースが作成できるようにしました。
gemにmysql2を追記したのでbundle installして実行して下さい。
rake db:createを実行して
recode_of_reading_development
recode_of_reading_test
というデータベースが作成できれば成功です。
よろしくお願いいたします。
